### PR TITLE
Fix menu item highlighting on multilingual sites

### DIFF
--- a/wowchemy/layouts/partials/navbar.html
+++ b/wowchemy/layouts/partials/navbar.html
@@ -100,7 +100,7 @@
             {{ if eq (len $hash_removed) 0 }}
               {{ $hash_removed = "/" }}{{/* Add robustness for `/#SECTION` or `#SECTION` in `menus.toml`. */}}
             {{ end }}
-            {{ $is_same_page = eq (path.Dir $current_page.RelPermalink) (path.Dir ($hash_removed|relLangURL)) }}
+            {{ $is_same_page = eq (path.Dir $current_page.RelPermalink) ((path.Dir $hash_removed)|relLangURL) }}
           {{ end }}
         {{end}}
 


### PR DESCRIPTION
This patch should fix an issue with menu items highlighting on multilingual sites.
In my case they are not highlighted when scrolling the translation of main page.

At the second element of comparison in line:
https://github.com/wowchemy/wowchemy-hugo-modules/blob/93ce3d22adfcd4ddde6e8bc8f74939ef09eb3c9c/wowchemy/layouts/partials/navbar.html#L103
path.Dir is applied after relLangURL. It crops `/<lang>` path (the result of `$hash_removed | relLangURL` expression) on the main translation page down to `/`. It does not match the result of `path.Dir $current_page.RelPermalink` expression (i.e. `/<lang>`) on the same page and the `data-target` attribute is not set for a menu item.

Swapping the order of relLangURL and path.Dir operations fixed the issue to me.